### PR TITLE
Update the `compat` entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-IntervalArithmetic = "0.15, 0.16"
-RecipesBase = "0.5,  0.6, 0.7, 0.8"
+IntervalArithmetic = "0.15, 0.16, 0.17"
+RecipesBase = "0.5, 0.6, 0.7, 0.8, ~1.0, ~1.1"
 julia = "1.0"


### PR DESCRIPTION
Both `IntervalArithmetic@0.16.7` and `RecipesBase@0.8.0` restrict `Plots` to version `0.29.9`, which is quite old and causes errors when using my package based on yours. Please, update your dependency versions.